### PR TITLE
Bump plugin version and update deps

### DIFF
--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "ttscast",
 	"name": "TTS Cast",
-	"pluginVersion": "1.8.8",
+	"pluginVersion": "1.8.9",
 	"description": {
 		"fr_FR": "Plugin pour gérer ses équipements Google, type Google Home, Nest Mini, Nest Hub (Max), Chromecast. Il permet de générer des notifications TTS (Text To Speech) et de les diffuser sur les équipements Google. Il permet également de diffuser des sons (mp3), des vidéos YouTube, une page Web, ou encore une radio en streaming sur ces mêmes équipements.",
 		"en_US": "Plugin to manage Google equipment, such as Google Home, Nest Mini, Nest Hub (Max), Chromecast. It allows you to generate TTS (Text To Speech) notifications and broadcast them to Google devices. It also allows you to broadcast sounds (mp3), YouTube videos, a web page, or even streaming radio on the same equipment.",

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,6 +1,6 @@
-PyChromecast==14.0.9
-google-cloud-texttospeech==2.34.0
+PyChromecast==14.0.10
+google-cloud-texttospeech==2.36.0
 gTTS==2.5.4
-google-genai==1.63.0
+google-genai==1.70.0
 Markdown==3.10.2
 beautifulsoup4==4.14.3


### PR DESCRIPTION
Bump plugin version to 1.8.9 and update Python dependencies in resources/requirements.txt. Updated packages: PyChromecast 14.0.9 -> 14.0.10, google-cloud-texttospeech 2.34.0 -> 2.36.0, google-genai 1.63.0 -> 1.70.0. No other functional changes.