### PR TITLE
v1.8.10

### DIFF
--- a/core/php/.htaccess
+++ b/core/php/.htaccess
@@ -1,2 +1,0 @@
-Order allow,deny
-Deny from all

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "ttscast",
 	"name": "TTS Cast",
-	"pluginVersion": "1.8.9",
+	"pluginVersion": "1.8.10",
 	"description": {
 		"fr_FR": "Plugin pour gérer ses équipements Google, type Google Home, Nest Mini, Nest Hub (Max), Chromecast. Il permet de générer des notifications TTS (Text To Speech) et de les diffuser sur les équipements Google. Il permet également de diffuser des sons (mp3), des vidéos YouTube, une page Web, ou encore une radio en streaming sur ces mêmes équipements.",
 		"en_US": "Plugin to manage Google equipment, such as Google Home, Nest Mini, Nest Hub (Max), Chromecast. It allows you to generate TTS (Text To Speech) notifications and broadcast them to Google devices. It also allows you to broadcast sounds (mp3), YouTube videos, a web page, or even streaming radio on the same equipment.",

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -194,21 +194,27 @@ function ttscast_update() {
             // Accepte fichiers ET répertoires (rm -rf) — ajouter ici les chemins à supprimer à chaque mise à jour
             $pluginDir . '/core/php/.htaccess',
         );
+        $cleanupRemoved = 0;
+        $cleanupErrors = 0;
         foreach ($pathsToRemove as $path) {
-            log::add('ttscast', 'debug', '[CLEANUP] Vérification du chemin : ' . $path);
             if (file_exists($path)) {
                 $output = array();
                 $returnVar = 0;
                 exec('rm -rf ' . escapeshellarg($path) . ' 2>&1', $output, $returnVar);
                 if ($returnVar !== 0) {
+                    $cleanupErrors++;
                     log::add('ttscast', 'warning', '[CLEANUP_KO] Echec suppression "' . $path . '" (Code: ' . $returnVar . ') : ' . implode(' ', $output));
                 } else {
+                    $cleanupRemoved++;
                     log::add('ttscast', 'info', '[CLEANUP_OK] Chemin supprimé : ' . $path);
                 }
-            } else {
-                log::add('ttscast', 'debug', '[CLEANUP_NA] Chemin non trouvé, aucune action : ' . $path);
             }
         }
+        $cleanupSummary = count($pathsToRemove) . ' chemin(s) vérifié(s), ' . $cleanupRemoved . ' supprimé(s)';
+        if ($cleanupErrors > 0) {
+            $cleanupSummary .= ', ' . $cleanupErrors . ' erreur(s)';
+        }
+        log::add('ttscast', 'debug', '[CLEANUP] ' . $cleanupSummary);
     } catch (Exception $e) {
         log::add('ttscast', 'warning', '[CLEANUP_KO] Erreur lors du nettoyage : ' . $e->getMessage());
     }

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -187,6 +187,32 @@ function ttscast_update() {
         }
     }
     
+    // Nettoyage des anciens fichiers et répertoires obsolètes
+    $pluginDir = dirname(__DIR__);
+    try {
+        $pathsToRemove = array(
+            // Accepte fichiers ET répertoires (rm -rf) — ajouter ici les chemins à supprimer à chaque mise à jour
+            $pluginDir . '/core/php/.htaccess',
+        );
+        foreach ($pathsToRemove as $path) {
+            log::add('ttscast', 'debug', '[CLEANUP] Vérification du chemin : ' . $path);
+            if (file_exists($path)) {
+                $output = array();
+                $returnVar = 0;
+                exec('rm -rf ' . escapeshellarg($path) . ' 2>&1', $output, $returnVar);
+                if ($returnVar !== 0) {
+                    log::add('ttscast', 'warning', '[CLEANUP_KO] Echec suppression "' . $path . '" (Code: ' . $returnVar . ') : ' . implode(' ', $output));
+                } else {
+                    log::add('ttscast', 'info', '[CLEANUP_OK] Chemin supprimé : ' . $path);
+                }
+            } else {
+                log::add('ttscast', 'debug', '[CLEANUP_NA] Chemin non trouvé, aucune action : ' . $path);
+            }
+        }
+    } catch (Exception $e) {
+        log::add('ttscast', 'warning', '[CLEANUP_KO] Erreur lors du nettoyage : ' . $e->getMessage());
+    }
+
     // Créer l'équipement AI Stats si l'IA est déjà activée
     ttscast::manageAIStatsEquipment();
 }


### PR DESCRIPTION
This pull request introduces a minor version update for the TTS Cast plugin, primarily focused on improving plugin maintenance by cleaning up obsolete files during updates. The most significant change is the automated removal of the now-unnecessary `.htaccess` file from the plugin's core PHP directory.

Maintenance and cleanup improvements:

* Added a cleanup routine to `ttscast_update()` in `install.php` that automatically removes obsolete files and directories (currently targeting `core/php/.htaccess`) during plugin updates. This helps keep the plugin directory clean and avoids potential security or compatibility issues with legacy files.
* Removed the obsolete `.htaccess` file from `core/php/`, as it is no longer needed.

Version update:

* Updated the plugin version in `info.json` from `1.8.9` to `1.8.10` to reflect these maintenance changes.