### PR TITLE
v1.8.12

### DIFF
--- a/core/class/.htaccess
+++ b/core/class/.htaccess
@@ -1,2 +1,1 @@
-Order allow,deny
-Deny from all
+Require all denied

--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,6 +1,5 @@
 Options +FollowSymLinks
-Order allow,deny
 <Files ~ "\.(mp3|png)$">
-   allow from all
+    Require all granted
 </Files>
-Deny from all
+Require all denied

--- a/plugin_info/.htaccess
+++ b/plugin_info/.htaccess
@@ -1,5 +1,4 @@
-Order allow,deny
 <Files ~ "\.(jpg|jpeg|png|gif|pdf|txt|bmp)$">
-   allow from all
+    Require all granted
 </Files>
-Deny from all
+Require all denied

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "ttscast",
 	"name": "TTS Cast",
-	"pluginVersion": "1.8.11",
+	"pluginVersion": "1.8.12",
 	"description": {
 		"fr_FR": "Plugin pour gérer ses équipements Google, type Google Home, Nest Mini, Nest Hub (Max), Chromecast. Il permet de générer des notifications TTS (Text To Speech) et de les diffuser sur les équipements Google. Il permet également de diffuser des sons (mp3), des vidéos YouTube, une page Web, ou encore une radio en streaming sur ces mêmes équipements.",
 		"en_US": "Plugin to manage Google equipment, such as Google Home, Nest Mini, Nest Hub (Max), Chromecast. It allows you to generate TTS (Text To Speech) notifications and broadcast them to Google devices. It also allows you to broadcast sounds (mp3), YouTube videos, a web page, or even streaming radio on the same equipment.",

--- a/resources/.htaccess
+++ b/resources/.htaccess
@@ -1,2 +1,1 @@
-Order allow,deny
-Deny from all
+Require all denied

--- a/resources/ttscastd/.htaccess
+++ b/resources/ttscastd/.htaccess
@@ -1,2 +1,1 @@
-Order allow,deny
-Deny from all
+Require all denied


### PR DESCRIPTION
This pull request updates several `.htaccess` files to use modern Apache 2.4 syntax for access control, improving security and compatibility. Additionally, it increments the plugin version in `info.json` to reflect these changes.

**Access control updates:**

* Updated `.htaccess` files in `core/class`, `data`, `plugin_info`, `resources`, and `resources/ttscastd` to replace deprecated `Order`/`Deny`/`allow from all` directives with `Require all denied` and `Require all granted` as appropriate for Apache 2.4+ compatibility. [[1]](diffhunk://#diff-58dd559e296421f967e2296183e7100e87daf05e2e6ad769643a46a5783769b1L1-R1) [[2]](diffhunk://#diff-1d5b7a55c14e180a4fa0f1705f99b3f1b41b72eeaa74d3584e1ad607b6db1c39L2-R5) [[3]](diffhunk://#diff-c411d8a20a1a566aa8322d9aa9efcd3915dd51a0d94be739cd8f8f1ce5691f58L1-R4) [[4]](diffhunk://#diff-e85cf62a67df14501a4afeeba09121fb4695791858feb1c363bde2e980072f78L1-R1)

**Metadata update:**

* Bumped the plugin version from `1.8.11` to `1.8.12` in `plugin_info/info.json` to reflect the changes.