### PR TITLE
v1.9.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
         "authmode",
         "bigben",
         "bubbleupnp",
+        "castloglevel",
         "chromecast",
         "chromecasts",
         "cmdwaittimeout",

--- a/core/class/ttscast.class.php
+++ b/core/class/ttscast.class.php
@@ -162,6 +162,7 @@ class ttscast extends eqLogic
         $path = realpath(__DIR__ . '/../../resources/ttscastd');
         $cmd = self::PYTHON3_PATH . " {$path}/ttscastd.py";
         $cmd .= ' --loglevel ' . log::convertLogLevel(log::getLogLevel(__CLASS__));
+        $cmd .= ' --castloglevel ' . config::byKey('castLogLevel', __CLASS__, 'daemon');
         $cmd .= ' --pluginversion ' . config::byKey('pluginVersion', __CLASS__, '0.0.0');
         $cmd .= ' --socketport ' . config::byKey('socketport', __CLASS__, '55111');
         $cmd .= ' --cyclefactor ' . config::byKey('cyclefactor', __CLASS__, '1');

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -97,22 +97,6 @@ if (!isConnect()) {
                 </div>
             </div>
             <div class="form-group">
-                <label class="col-lg-3 control-label">{{Niveau de log Chromecast}}
-                    <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
-                    <sup><i class="fas fa-question-circle tooltips" title="{{Niveau de log des librairies Chromecast du démon. Par défaut, hérite du niveau de log global.}}"></i></sup>
-                </label>
-                <div class="col-lg-2">
-                    <select class="configKey form-control" data-l1key="castLogLevel">
-                        <option value="daemon" selected>{{Identique au démon (défaut)}}</option>
-                        <option value="debug">{{Debug}}</option>
-                        <option value="info">{{Info}}</option>
-                        <option value="warning">{{Warning}}</option>
-                        <option value="error">{{Error}}</option>
-                        <option value="critical">{{Critical}}</option>
-                    </select>
-                </div>
-            </div>
-            <div class="form-group">
 	            <label class="col-lg-3 control-label">{{Fréquence des cycles}}
                     <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>    
                     <sup><i class="fas fa-question-circle tooltips" title="{{Facteur multiplicateur des cycles du démon (Défaut = x1)}}"></i></sup>
@@ -128,6 +112,22 @@ if (!isConnect()) {
 			            <option value="3.0">{{Lent --- (x3)}}</option>
 			        </select>
 	            </div>
+            </div>
+            <div class="form-group">
+                <label class="col-lg-3 control-label">{{Niveau de log Chromecast}}
+                    <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
+                    <sup><i class="fas fa-question-circle tooltips" title="{{Niveau de log des librairies Chromecast du démon. Par défaut, hérite du niveau de log global.}}"></i></sup>
+                </label>
+                <div class="col-lg-2">
+                    <select class="configKey form-control" data-l1key="castLogLevel">
+                        <option value="daemon" selected>{{Identique au démon (défaut)}}</option>
+                        <option value="debug">{{Debug}}</option>
+                        <option value="info">{{Info}}</option>
+                        <option value="warning">{{Warning}}</option>
+                        <option value="error">{{Error}}</option>
+                        <option value="critical">{{Critical}}</option>
+                    </select>
+                </div>
             </div>
             <legend><i class="fab fa-chromecast"></i> {{TTS (Text To Speech)}}</legend>
             <div class="form-group">

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -97,6 +97,22 @@ if (!isConnect()) {
                 </div>
             </div>
             <div class="form-group">
+                <label class="col-lg-3 control-label">{{Niveau de log Chromecast}}
+                    <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>
+                    <sup><i class="fas fa-question-circle tooltips" title="{{Niveau de log des librairies Chromecast du démon. Par défaut, hérite du niveau de log global.}}"></i></sup>
+                </label>
+                <div class="col-lg-2">
+                    <select class="configKey form-control" data-l1key="castLogLevel">
+                        <option value="daemon" selected>{{Identique au démon (défaut)}}</option>
+                        <option value="debug">{{Debug}}</option>
+                        <option value="info">{{Info}}</option>
+                        <option value="warning">{{Warning}}</option>
+                        <option value="error">{{Error}}</option>
+                        <option value="critical">{{Critical}}</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
 	            <label class="col-lg-3 control-label">{{Fréquence des cycles}}
                     <sup><i class="fas fa-exclamation-triangle tooltips" style="color:var(--al-warning-color)!important;" title="{{Le démon devra être redémarré après la modification de ce paramètre}}"></i></sup>    
                     <sup><i class="fas fa-question-circle tooltips" title="{{Facteur multiplicateur des cycles du démon (Défaut = x1)}}"></i></sup>

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "ttscast",
 	"name": "TTS Cast",
-	"pluginVersion": "1.9.3",
+	"pluginVersion": "1.9.4",
 	"description": {
 		"fr_FR": "Plugin pour gérer ses équipements Google, type Google Home, Nest Mini, Nest Hub (Max), Chromecast. Il permet de générer des notifications TTS (Text To Speech) et de les diffuser sur les équipements Google. Il permet également de diffuser des sons (mp3), des vidéos YouTube, une page Web, ou encore une radio en streaming sur ces mêmes équipements.",
 		"en_US": "Plugin to manage Google equipment, such as Google Home, Nest Mini, Nest Hub (Max), Chromecast. It allows you to generate TTS (Text To Speech) notifications and broadcast them to Google devices. It also allows you to broadcast sounds (mp3), YouTube videos, a web page, or even streaming radio on the same equipment.",

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -88,6 +88,9 @@ function ttscast_install() {
     if (config::byKey('streamingDefault', 'ttscast') == '') {
         config::save('streamingDefault', '0', 'ttscast');
     }
+    if (config::byKey('castLogLevel', 'ttscast') == '') {
+        config::save('castLogLevel', 'daemon', 'ttscast');
+    }
     if (config::byKey('disableUpdateMsg', 'ttscast') == '') {
         config::save('disableUpdateMsg', '0', 'ttscast');
     }
@@ -176,6 +179,9 @@ function ttscast_update() {
     }
     if (config::byKey('streamingDefault', 'ttscast') == '') {
         config::save('streamingDefault', '0', 'ttscast');
+    }
+    if (config::byKey('castLogLevel', 'ttscast') == '') {
+        config::save('castLogLevel', 'daemon', 'ttscast');
     }
     if (config::byKey('disableUpdateMsg', 'ttscast') == '') {
         config::save('disableUpdateMsg', '0', 'ttscast');

--- a/resources/ttscastd/ttscastd.py
+++ b/resources/ttscastd/ttscastd.py
@@ -3617,6 +3617,7 @@ myConfig = Config()
 
 parser = argparse.ArgumentParser(description='TTSCast Daemon for Jeedom plugin')
 parser.add_argument("--loglevel", help="Log Level for the daemon", type=str)
+parser.add_argument("--castloglevel", help="Log Level for Chromecast libraries (pychromecast, zeroconf)", type=str, default='daemon')
 parser.add_argument("--pluginversion", help="Plugin Version", type=str)
 parser.add_argument("--callback", help="Callback", type=str)
 parser.add_argument("--apikey", help="ApiKey", type=str)
@@ -3650,6 +3651,8 @@ parser.add_argument("--streamingdefault", help="Enable streaming TTS by default"
 args = parser.parse_args()
 if args.loglevel:
     myConfig.logLevel = args.loglevel
+if args.castloglevel:
+    myConfig.castLogLevel = args.castloglevel
 if args.pluginversion:
     myConfig.pluginVersion = args.pluginversion
 if args.callback:
@@ -3741,6 +3744,11 @@ if args.ttsweb:
 
 jeedom_utils.set_log_level(myConfig.logLevel)
 
+if myConfig.castLogLevel != 'daemon':
+    _cast_level = jeedom_utils.convert_log_level(myConfig.castLogLevel)
+    logging.getLogger('pychromecast').setLevel(_cast_level)
+    logging.getLogger('zeroconf').setLevel(_cast_level)
+
 if myConfig.cycleFactor == 0:
     myConfig.cycleMain = 2.0
     myConfig.cycleComm = 0.5
@@ -3758,6 +3766,7 @@ logging.info('[DAEMON][MAIN] Start Daemon')
 logging.info('[DAEMON][MAIN] Plugin Version: %s', myConfig.pluginVersion)
 logging.info('[DAEMON][MAIN] Python Version: %s', sys.version)
 logging.info('[DAEMON][MAIN] Log level: %s', myConfig.logLevel)
+logging.info('[DAEMON][MAIN] Cast log level: %s', myConfig.castLogLevel)
 logging.info('[DAEMON][MAIN] Socket port: %s', myConfig.socketPort)
 logging.info('[DAEMON][MAIN] Socket host: %s', myConfig.socketHost)
 logging.info('[DAEMON][MAIN] CycleFactor: %s', myConfig.cycleFactor)

--- a/resources/ttscastd/utils.py
+++ b/resources/ttscastd/utils.py
@@ -130,6 +130,7 @@ class Config:
     cmdWaitQueue = {}
     
     logLevel = "error"
+    castLogLevel = "daemon"
     socketPort = 55111
     socketHost = 'localhost'
     pidFile = '/tmp/ttscastd.pid'


### PR DESCRIPTION
This pull request introduces a new configurable log level specifically for Chromecast-related libraries, allowing users to control the verbosity of logs from `pychromecast` and `zeroconf` independently from the main daemon log level. It also updates the plugin version and ensures the new setting is properly initialized during installation and updates.

**Chromecast log level configuration:**

* Added a new configuration option `castLogLevel` to allow users to select the log level for Chromecast libraries via the plugin settings UI (`plugin_info/configuration.php`).
* Updated the Python daemon (`ttscastd.py`) to accept and apply the `--castloglevel` argument, setting the log level for `pychromecast` and `zeroconf` accordingly. [[1]](diffhunk://#diff-8b558327ddc49dd795d6bd1f1d7c1b3fc53cb7fc5b3f7367ee0169374e0cc8feR3620) [[2]](diffhunk://#diff-8b558327ddc49dd795d6bd1f1d7c1b3fc53cb7fc5b3f7367ee0169374e0cc8feR3654-R3655) [[3]](diffhunk://#diff-8b558327ddc49dd795d6bd1f1d7c1b3fc53cb7fc5b3f7367ee0169374e0cc8feR3747-R3751) [[4]](diffhunk://#diff-8b558327ddc49dd795d6bd1f1d7c1b3fc53cb7fc5b3f7367ee0169374e0cc8feR3769) [[5]](diffhunk://#diff-8b627d8e7fd7a05184723f68662b99bfdb4db4a41507391da55ba00122f57c81R133)
* Modified the daemon start command in `ttscast.class.php` to include the `--castloglevel` parameter, passing the configured value to the daemon process.
* Ensured the `castLogLevel` setting is initialized to a default value (`daemon`) during both plugin installation and updates (`install.php`). [[1]](diffhunk://#diff-d29ad66623b8d1c93164e29ccae746ec492d78c2a5f7f10a2eb8b6ab450cb292R91-R93) [[2]](diffhunk://#diff-d29ad66623b8d1c93164e29ccae746ec492d78c2a5f7f10a2eb8b6ab450cb292R183-R185)
* Added `castloglevel` to the list of known settings in `.vscode/settings.json` for improved development experience.

**Other changes:**

* Bumped the plugin version from `1.9.3` to `1.9.4` in `info.json` to reflect these updates.