### PR TITLE
Bump google-genai to 2.8.0

### DIFF
--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,6 +1,6 @@
 PyChromecast==14.0.10
 google-cloud-texttospeech==2.36.0
 gTTS==2.5.4
-google-genai==2.7.0
+google-genai==2.8.0
 Markdown==3.10.2
 beautifulsoup4==4.14.3


### PR DESCRIPTION
Update resources/requirements.txt to bump google-genai from 2.7.0 to 2.8.0 to pick up upstream fixes and improvements.