### PR TITLE
Use --no-cache-dir for pip installs

### DIFF
--- a/resources/install_apt.sh
+++ b/resources/install_apt.sh
@@ -223,10 +223,10 @@ echo 70 > ${PROGRESS_FILE}
 log "*****************************"
 log "* Install Python3 libraries *"
 log "*****************************"
-${VENV_DIR}/bin/python3 -m pip install --upgrade pip wheel | log
+${VENV_DIR}/bin/python3 -m pip install --no-cache-dir --upgrade pip wheel | log
 log "** Install Pip / Wheel :: Done **"
 echo 75 > ${PROGRESS_FILE}
-${VENV_DIR}/bin/python3 -m pip install -r ${REQUIREMENTS_FILE} | log
+${VENV_DIR}/bin/python3 -m pip install --no-cache-dir -r ${REQUIREMENTS_FILE} | log
 log "** Install Python3 libraries :: Done **"
 echo 95 > ${PROGRESS_FILE}
 log "****************************"


### PR DESCRIPTION
This pull request makes a minor update to the Python package installation process in the `resources/install_apt.sh` script. The change ensures that pip installs do not use the local cache, which can help avoid issues with stale or corrupted packages.

- Python package installation now uses the `--no-cache-dir` option for both upgrading pip/wheel and installing from `requirements.txt` to prevent using cached packages (`resources/install_apt.sh`).