### PR TITLE
Use pip --no-cache-dir and remove sudo

### DIFF
--- a/core/class/ttscast.class.php
+++ b/core/class/ttscast.class.php
@@ -117,7 +117,7 @@ class ttscast extends eqLogic
                 $return['state'] = 'nok';
             } elseif (!file_exists(self::PYTHON3_PATH)) {
                 $return['state'] = 'nok';
-            } elseif (exec(system::getCmdSudo() . self::PYTHON3_PATH . ' -m pip freeze | grep -Eiwc "' . config::byKey('pythonDepString', 'ttscast', '', true) . '"') < config::byKey('pythonDepNum', 'ttscast', 0, true)) {
+            } elseif (exec(self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze | grep -Eiwc "' . config::byKey('pythonDepString', 'ttscast', '', true) . '"') < config::byKey('pythonDepNum', 'ttscast', 0, true)) {
                 log::add('ttscast', 'warning', '[DepInfo] Missing Python dependencies');
                 $return['state'] = 'nok';
             } else {


### PR DESCRIPTION
Update dependency check in core/class/ttscast.class.php to invoke Python's pip without system::getCmdSudo() and add the --no-cache-dir flag to pip freeze. This avoids relying on sudo and prevents pip cache interference when counting installed dependencies via grep, improving reliability of the check.