### PR TITLE
Use pip --no-cache-dir and remove sudo

### DIFF
--- a/core/class/ttscast.class.php
+++ b/core/class/ttscast.class.php
@@ -117,7 +117,7 @@ class ttscast extends eqLogic
                 $return['state'] = 'nok';
             } elseif (!file_exists(self::PYTHON3_PATH)) {
                 $return['state'] = 'nok';
-            } elseif (exec(system::getCmdSudo() . self::PYTHON3_PATH . ' -m pip freeze | grep -Eiwc "' . config::byKey('pythonDepString', 'ttscast', '', true) . '"') < config::byKey('pythonDepNum', 'ttscast', 0, true)) {
+            } elseif (exec(self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze | grep -Eiwc "' . config::byKey('pythonDepString', 'ttscast', '', true) . '"') < config::byKey('pythonDepNum', 'ttscast', 0, true)) {
                 log::add('ttscast', 'warning', '[DepInfo] Missing Python dependencies');
                 $return['state'] = 'nok';
             } else {


### PR DESCRIPTION
This pull request updates the way Python dependencies are checked in the `ttscast` core class. The main improvement is to ensure that the dependency check uses a more reliable and efficient command by removing unnecessary `sudo` usage and disabling pip's cache.

Dependency check improvement:

* Updated the dependency check in `ttscast.class.php` to run the `pip freeze` command without `sudo` and with the `--no-cache-dir` flag for better reliability and security.