### PR TITLE
Improve Python dependency checks and logging

### DIFF
--- a/core/class/ttscast.class.php
+++ b/core/class/ttscast.class.php
@@ -109,20 +109,34 @@ class ttscast extends eqLogic
         $return = array();
         $return['log'] = log::getPathToLog(__CLASS__ . '_update');
         $return['progress_file'] = jeedom::getTmpFolder(__CLASS__) . '/dependency';
+
         if (file_exists(jeedom::getTmpFolder(__CLASS__) . '/dependency')) {
             $return['state'] = 'in_progress';
         } else {
             if (exec(system::getCmdSudo() . system::get('cmd_check') . '-Ec "python3\-requests|python3\-setuptools|python3\-dev|python3\-venv"') < 4) {
-                log::add('ttscast', 'warning', '[DepInfo] Missing system dependencies');
                 $return['state'] = 'nok';
+                log::add(__CLASS__, 'debug', '[Python-Dep] System packages missing (python3-requests, python3-setuptools, python3-dev, or python3-venv)');
             } elseif (!file_exists(self::PYTHON3_PATH)) {
                 $return['state'] = 'nok';
-            } elseif (exec(self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze | grep -Eiwc "' . config::byKey('pythonDepString', 'ttscast', '', true) . '"') < config::byKey('pythonDepNum', 'ttscast', 0, true)) {
-                log::add('ttscast', 'warning', '[DepInfo] Missing Python dependencies');
-                $return['state'] = 'nok';
+                log::add(__CLASS__, 'debug', '[Python-Dep] Python venv executable not found at: ' . self::PYTHON3_PATH);
             } else {
-                log::add('ttscast', 'info', '[DepInfo] All dependencies are installed');
-                $return['state'] = 'ok';
+                $expectedCount = config::byKey('pythonDepNum', 'ttscast', 0, true);
+                $pythonDepString = config::byKey('pythonDepString', 'ttscast', '', true);
+
+                $cmd = self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze | grep -Ewci "' . $pythonDepString . '"';
+                $foundCount = exec($cmd);
+
+                if ($foundCount < $expectedCount) {
+                    $return['state'] = 'nok';
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Missing Dependencies. Found: ' . $foundCount . ' / Expected: ' . $expectedCount);
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Regex used: ' . $pythonDepString);
+                    // Log actual pip freeze content for debugging
+                    $pipFreeze = shell_exec(self::PYTHON3_PATH . ' -m pip --no-cache-dir freeze');
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Pip Freeze Output: ' . str_replace(PHP_EOL, ' | ', trim($pipFreeze)));
+                } else {
+                    $return['state'] = 'ok';
+                    log::add(__CLASS__, 'debug', '[Python-Dep] Dependencies installed. State : OK');
+                }
             }
         }
         return $return;


### PR DESCRIPTION
Enhance dependency verification and add detailed debug logs for ttscast.

Replaced generic warning/info messages with structured debug entries, added explicit checks and messages for missing system packages and missing Python venv executable, and implemented counting of installed Python packages using configured regex and expected count (pythonDepString / pythonDepNum). When dependencies are missing, the code now logs the found vs expected count, the regex used, and the full pip freeze output (compressed) to aid troubleshooting. Overall behavior for setting the dependency state (ok/nok/in_progress) is preserved but with richer diagnostics.